### PR TITLE
Use Go 11 modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/kinvolk/straceback
+
+go 1.12
+
+require github.com/iovisor/gobpf v0.0.0-20190329163444-e0d8d785d368
+
+replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1 h1:Lk6hLMmaTUaLt6GQrIhJHN+6yAHw4NW98KUOD+vnfGw=
+github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=


### PR DESCRIPTION
Replaces iovisor/gobpf with https://github.com/kinvolk/gobpf/tree/alban/straceback
as currently required.
When the go.mod file is updated, branch names can be used to replace the
v…commit specifier and they will be replaced with a specific commit on the next build.