### PR TITLE
Dump multiple times and concatenate dumps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.12
 
 require github.com/iovisor/gobpf v0.0.0-20190329163444-e0d8d785d368
 
-replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1
+replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
-github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1 h1:Lk6hLMmaTUaLt6GQrIhJHN+6yAHw4NW98KUOD+vnfGw=
-github.com/kinvolk/gobpf v0.0.0-20190426145724-a01317ace7a1/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
+github.com/kinvolk/gobpf v0.0.0-20190520160016-627240a2ec0a h1:dG8svxFoLDFvL2KBadSYXGi0p6CQCpJQqaRb8hZRn5A=
+github.com/kinvolk/gobpf v0.0.0-20190520160016-627240a2ec0a/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
+github.com/kinvolk/gobpf v0.0.0-20190904163508-70f33f7f474b h1:HnF6m6R6vgEzok/rUw0NxWZTSN36+QtNSTbxvK6vM+Q=
+github.com/kinvolk/gobpf v0.0.0-20190904163508-70f33f7f474b/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
+github.com/kinvolk/gobpf v0.0.0-20190904215738-dfd718d01dee h1:YS8x2QSldVkEOf2qD7QFHNxgWhXm6X5jyYwlPHCEHqM=
+github.com/kinvolk/gobpf v0.0.0-20190904215738-dfd718d01dee/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
+github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270 h1:G5SH709F7qtuxvHiwd3hmvBXO0ss2K2OzrJfAAQvPvg=
+github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=


### PR DESCRIPTION
Due to the limitations imposed by the backward perf ring buffers (they cannot
    be read while written) traceloop was only able to dump the trace once.
    
This commit uses the new SwapAndDumpBackwards method that allows to perform
    multiple dumps over the same perf ring buffer. The dumps are concatenated
    before they are interpreted as strings because interpretation requires that
    all events of a syscall are in one dump. The maximal length of the dumps is
    specified by a constant for now. In interactive mode the buffer is swapped
    four times per second. *A marker for missed events when the ring buffer was
    full would be needed to make clear that the concatenation can miss events.*
    
Co-authored-by: Mauricio Vasquez <mauricio@kinvolk.io>
