### PR TITLE
Improve interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ used with systemd services that are in their own control groups (look for
 
 Example with an existing systemd service:
 ```
-sudo -E ./traceloop /sys/fs/cgroup/unified/system.slice/sshd.service
+sudo -E ./traceloop cgroups /sys/fs/cgroup/unified/system.slice/sshd.service
 ```
 
 Example with a custom command:
 ```
 sudo systemd-run -t  --unit=test42.service  /bin/sh -c 'for i in $(seq 1 1000) ; do sleep 4 ; echo 2*3*7 | bc > /dev/null ; echo Multiplication $i done. ; done'
 ...
-sudo -E ./traceloop /sys/fs/cgroup/unified/system.slice/test42.service
+sudo -E ./traceloop cgroups /sys/fs/cgroup/unified/system.slice/test42.service
 ...
 00:04.022260640 cpu#0 pid 23981 [bc] brk(brk=0) = 94045092683776
 00:04.022346588 cpu#0 pid 23981 [bc] ioctl(fd=0, cmd=21505, arg=140721805741680) = 18446744073709551591

--- a/pkg/straceback/straceback.go
+++ b/pkg/straceback/straceback.go
@@ -893,6 +893,13 @@ func (sb *StraceBack) CloseProg(id uint32) (err error) {
 	return
 }
 
+func (sb *StraceBack) GetCgroupPath(id uint32) (out string, err error) {
+	if id >= uint32(C.MaxTracedPrograms) || sb.tracelets[id] == nil {
+		return "", fmt.Errorf("invalid index")
+	}
+	return sb.tracelets[id].cgroupPath, nil
+}
+
 func (sb *StraceBack) CloseProgByName(name string) (err error) {
 	for i := 0; i < int(C.MaxTracedPrograms); i++ {
 		if sb.tracelets[i] != nil && sb.tracelets[i].description == name {

--- a/traceloop.go
+++ b/traceloop.go
@@ -218,15 +218,25 @@ LOOP:
 			break LOOP
 		}
 
-		for _, id := range ids {
+		for n, id := range ids {
+			cgroupPath, err := t.GetCgroupPath(id)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
 			_ = t.DumpProgWithQueue(id)
 			out, err := t.DumpProg(id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}
-			// Clear screen to remove old contents before printing the full log again
-			fmt.Printf("\033[2J%s", out)
+			clearScreen := ""
+			if n == 0 {
+				// Clear screen to remove old contents before printing the full log again
+				clearScreen = "\033[2J"
+			}
+			fmt.Printf("%s\nDump for %s:\n%sEnd of dump for %s (Press Ctrl-S to pause, Ctrl-Q to continue, Ctrl-C to quit)\n",
+				clearScreen, cgroupPath, out, cgroupPath)
 		}
 	}
 


### PR DESCRIPTION
- Print which cgroup was dumped
- Print how to pause terminal output
- Print of usage information for the arguments `-h`, `--help`, or `help`
- Add mode to dump only on exit and not continuously