### PR TITLE
ci: install CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+jobs:
+ build:
+   docker:
+     - image: circleci/golang:1.12
+   working_directory: /go/src/github.com/kinvolk/traceloop
+   steps:
+     - checkout
+     - setup_remote_docker:
+         docker_layer_caching: true
+
+     # start proprietary DB using private Docker image
+     # with credentials stored in the UI
+     - run: |
+         echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+
+     # build the application image
+     - run: make all DOCKER_TAG=$CIRCLE_BRANCH
+
+     # deploy the image
+     - run: make docker/push DOCKER_TAG=$CIRCLE_BRANCH

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ BUILDER_DOCKER_FILE?=traceloop-builder.Dockerfile
 BUILDER_DOCKER_IMAGE?=kinvolk/traceloop-builder
 
 DOCKER_FILE?=traceloop.Dockerfile
-DOCKER_IMAGE?=kinvolk/traceloop
+IMAGE_TAG=$(shell ./tools/image-tag)
+DOCKER_IMAGE?=kinvolk/traceloop:$(IMAGE_TAG)
 
 # If you can use docker without being root, you can do "make SUDO="
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
@@ -16,15 +17,35 @@ all: build-docker-image build-bpf-object install-generated-go bin-traceloop dock
 build-docker-image:
 	$(SUDO) docker build -t $(BUILDER_DOCKER_IMAGE) -f $(BUILDER_DOCKER_FILE) .
 
+# CircleCI with Remote Docker has the following limitation:
+# https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
+# > It is not possible to mount a folder from your job space into a container
+# > in Remote Docker (and vice versa). You may use the docker cp command to
+# > transfer files between these two environments.
+ifeq ($(CIRCLECI),true)
+  DOCKER_VOLUMES=--name bpfbuild --volumes-from sources
+else
+  DOCKER_VOLUMES=--rm -v $(PWD):/src:ro -v $(PWD)/bpf:/dist/
+endif
+
 build-bpf-object:
-	$(SUDO) docker run --rm -e DEBUG=$(DEBUG) \
+ifeq ($(CIRCLECI),true)
+	docker create -v /src -v /dist --name sources alpine:3.4 /bin/true
+	docker cp . sources:/src
+endif
+	$(SUDO) docker run -e DEBUG=$(DEBUG) \
 		-e CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
-		-v $(PWD):/src:ro \
-		-v $(PWD)/bpf:/dist/ \
+		$(DOCKER_VOLUMES) \
 		--workdir=/src \
 		$(BUILDER_DOCKER_IMAGE) \
 		make -f bpf.mk build
+ifeq ($(CIRCLECI),true)
+	docker cp bpfbuild:/dist/straceback-assets-bpf.go bpf/straceback-assets-bpf.go
+	docker container rm bpfbuild
+	docker container rm sources
+else
 	sudo chown -R $(UID):$(UID) bpf
+endif
 
 install-generated-go:
 	cp bpf/straceback-assets-bpf.go pkg/straceback/straceback-assets-bpf.go
@@ -33,7 +54,7 @@ delete-docker-image:
 	$(SUDO) docker rmi -f $(BUILDER_DOCKER_IMAGE)
 
 bin-traceloop:
-	go build -o traceloop traceloop.go
+	GO111MODULE=on go build -o traceloop traceloop.go
 
 docker/image:
 	$(SUDO) docker build -t $(DOCKER_IMAGE) -f $(DOCKER_FILE) .

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.12
 
 require github.com/iovisor/gobpf v0.0.0-20190329163444-e0d8d785d368
 
-replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270
+replace github.com/iovisor/gobpf => github.com/kinvolk/gobpf v0.0.0-20191006160500-a7d6e01aa304

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/kinvolk/gobpf v0.0.0-20190520160016-627240a2ec0a h1:dG8svxFoLDFvL2KBadSYXGi0p6CQCpJQqaRb8hZRn5A=
-github.com/kinvolk/gobpf v0.0.0-20190520160016-627240a2ec0a/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
-github.com/kinvolk/gobpf v0.0.0-20190904163508-70f33f7f474b h1:HnF6m6R6vgEzok/rUw0NxWZTSN36+QtNSTbxvK6vM+Q=
-github.com/kinvolk/gobpf v0.0.0-20190904163508-70f33f7f474b/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
-github.com/kinvolk/gobpf v0.0.0-20190904215738-dfd718d01dee h1:YS8x2QSldVkEOf2qD7QFHNxgWhXm6X5jyYwlPHCEHqM=
-github.com/kinvolk/gobpf v0.0.0-20190904215738-dfd718d01dee/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
-github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270 h1:G5SH709F7qtuxvHiwd3hmvBXO0ss2K2OzrJfAAQvPvg=
-github.com/kinvolk/gobpf v0.0.0-20190905145713-231fd4025270/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=
+github.com/kinvolk/gobpf v0.0.0-20191006160500-a7d6e01aa304 h1:gRDqecTKQmAaSChOoIYYrNbweRevo8rbdc6V/i98wPQ=
+github.com/kinvolk/gobpf v0.0.0-20191006160500-a7d6e01aa304/go.mod h1:61h4gva56IGKqstHOMIC38bRpXailv183ew8e9w2AQo=

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Generate container tag names
+# From https://github.com/weaveworks/scope/blob/master/tools/image-tag
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
+BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
Install CircleCI. The build uses their Remote Docker. The built container image is pushed on Docker Hub with a tag based on the branch and commit.

Also update gobpf in go modules with this patch https://github.com/iovisor/gobpf/pull/208 for a build issue found along the way.

Builds URL: https://circleci.com/gh/kinvolk/traceloop
Container images: https://cloud.docker.com/u/kinvolk/repository/docker/kinvolk/traceloop/tags