### PR TITLE
Fix crash on PollStop when interrupting traceloop

### DIFF
--- a/pkg/straceback/straceback.go
+++ b/pkg/straceback/straceback.go
@@ -905,7 +905,9 @@ func (sb *StraceBack) CloseProgByName(name string) (err error) {
 
 func (sb *StraceBack) Stop() {
 	close(sb.stopChan)
-	sb.newContainerEventsMap.PollStop()
+	if sb.newContainerEventsMap != nil {
+		sb.newContainerEventsMap.PollStop()
+	}
 	for i, _ := range sb.tracelets {
 		if sb.tracelets[i] != nil {
 			sb.tracelets[i].pm.PollStop()


### PR DESCRIPTION
Symptoms:
```
[Trace is here…]
^CInterrupted!
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1173c9c]
goroutine 1 [running]:
github.com/iovisor/gobpf/elf.(*PerfMap).PollStop(...)
	/.../go/pkg/mod/github.com/kinvolk/gobpf@v0.0.0-20191127154002-f0f89e7c6fd1/elf/perf.go:411
github.com/kinvolk/traceloop/pkg/straceback.(*StraceBack).Stop(0xc000140630)
	/.../kinvolk/traceloop/pkg/straceback/straceback.go:908 +0x3c
main.main()
	/.../kinvolk/traceloop/traceloop.go:233 +0x856
```

Thanks @pothos for reporting.