### PR TITLE
Keep trace for 3 hours instead of 1 minute

### DIFF
--- a/pkg/straceback/straceback.go
+++ b/pkg/straceback/straceback.go
@@ -533,7 +533,7 @@ func (sb *StraceBack) recycleTracelets() error {
 			continue
 		}
 		fmt.Printf("recycle %d: time %v - %v\n", i, sb.tracelets[i].timeDeletion.Format(time.RFC3339), time.Now())
-		if sb.tracelets[i].timeDeletion.Add(time.Minute).Before(time.Now()) {
+		if sb.tracelets[i].timeDeletion.Add(time.Hour * 3).Before(time.Now()) {
 			fmt.Printf("Deleting tracelet #%d\n", i)
 			sb.CloseProg(uint32(i))
 


### PR DESCRIPTION
The new time is arbitrary as well but make the feature more usable because 1 minute is just too short even if I am aware of a pod crash.

Long term solution in https://github.com/kinvolk/traceloop/issues/24 (maybe with an additional option to configure a maximal time and storage size)