### PR TITLE
guess offsets: increase theshold for threshold_nsproxy

### DIFF
--- a/pkg/straceback/guesspidns.go
+++ b/pkg/straceback/guesspidns.go
@@ -20,9 +20,10 @@ type guessStatus C.struct_guess_status_t
 const (
 	// When reading kernel structs at different offsets, don't go over that
 	// limit. This is an arbitrary choice to avoid infinite loops.
-	threshold_nsproxy = 2500 // 1856
-	threshold_utsns   = 40   // 32
-	threshold_ino     = 500  // 184 + 16
+	// On Linux 5.5.5-200.fc31.x86_64, I have the following offsets: 2784 8 432
+	threshold_nsproxy = 3500
+	threshold_utsns   = 40
+	threshold_ino     = 500
 )
 
 // These constants should be in sync with the equivalent definitions in the ebpf program.


### PR DESCRIPTION
> overflow while guessing uts namespace, bailing out

Issue reported on https://github.com/kinvolk/inspektor-gadget/issues/63:
I can reproduce the issue on Fedora with Linux 5.5.5-200.fc31.x86_64.

For the record, for debugging this issue, I had prepared the following:

<details>
In order to debug this, I need to get some info from the kernel. traceloop tried to find out the offset of some fields in some kernel structs and failed.

I have written this [debug commit](https://github.com/kinvolk/bcc/commit/d9bc608f903978b0076c9abfd3eea1c05398d84e) in bcc and generated the docker image `kinvolk/bcc:alban-uts-offset` from it. It can be executed with the following command:
```
docker run --rm -ti --privileged --net=host --pid=host -v /usr/src:/usr/src -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug docker.io/kinvolk/bcc:alban-uts-offset /usr/share/bcc/tools/execsnoop
```
to see new processes and then check the output of:
```
sudo cat /sys/kernel/debug/tracing/trace_pipe
```
and see something like:
```
           <...>-3025022 [002] .... 1149258.679821: 0: offset_nsproxy: 2784
           <...>-3025022 [002] .N.. 1149258.679824: 0: offset_utsns: 8
           <...>-3025022 [002] .N.. 1149258.679825: 0: offset_ns: 416
           <...>-3025022 [002] .N.. 1149258.679826: 0: offset_ino: 16
```
</details>