### PR TITLE
Only fetch local pods

### DIFF
--- a/pkg/podinformer/podinformer.go
+++ b/pkg/podinformer/podinformer.go
@@ -28,6 +28,7 @@ package podinformer
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -81,7 +82,11 @@ func NewPodInformer(podInformerChan chan ContainerInfo) (*PodInformer, error) {
 	}
 
 	// create the pod watcher
-	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", "", fields.Everything())
+	node := os.Getenv("TRACELOOP_NODE_NAME")
+	if node == "" {
+		return nil, fmt.Errorf("Environment variable TRACELOOP_NODE_NAME not set")
+	}
+	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", "", fields.OneTermEqualSelector("spec.nodeName", node))
 
 	// creates the queue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())


### PR DESCRIPTION
Traceloop does not need to fetch pods on remote nodes. Use a field selector to filter pods.

----

Change similar to https://github.com/kinvolk/inspektor-gadget/pull/88

TODO:
- [x] Rebase once #44 is merged
- [x] Test