### PR TITLE
Support building with Podman instead of Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 VERSIONLDFLAGS := "-X main.version=$(VERSION)"
 
 DEBUG=1
-UID=$(shell id -u)
+SET_USER=$(shell (docker --version | grep -q podman) || echo "--user $(shell id -u)")
 PWD=$(shell pwd)
 
 BUILDER_DOCKER_FILE?=traceloop-builder.Dockerfile
@@ -49,7 +49,7 @@ ifeq ($(CIRCLECI),true)
 	docker create -v /src -v /dist --name sources alpine:3.4 /bin/true
 	docker cp . sources:/src
 endif
-	$(SUDO) docker run --user $(UID) -e DEBUG=$(DEBUG) \
+	$(SUDO) docker run $(SET_USER) -e DEBUG=$(DEBUG) \
 		-e CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
 		$(DOCKER_VOLUMES) \
 		--workdir=/src \


### PR DESCRIPTION
The Makefile specifies the user of the Docker container to be the
current user ID to set the correct file permissions. This does not
work with Podman where the container's root user is mapped on the
current user and the current user ID inside the container has no
sufficient permissions to write the files.
Do not set the user ID when building with Podman and rely on
Podman to map the root user of the container to the current user.