### PR TITLE
contrib: Add helper script to find the cgroup v2 path for a process, Add benchmark scripts

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,0 +1,2 @@
+results-*
+graph.png

--- a/contrib/current-cgroup
+++ b/contrib/current-cgroup
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -gt 0 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] ; }; then
+  echo "Helper script to find the current cgroup v2 path"
+  echo "Usage: [PID=PROCESS_ID] $0"
+  echo "  If PID is specified as environment variable, the cgroup path of"
+  echo "  the given PID will be queried. Otherwise the PID of the script"
+  echo "  process itself will be used."
+  exit 1
+fi
+
+PID="${PID:-$$}"
+
+PREFIX="$(mount -l -t cgroup2 | awk '{print $3}')"
+if [ "$PREFIX" = "" ]; then
+  echo "Error: Traceloop doesn't support cgroup v1" > /dev/stderr
+  exit 1
+fi
+
+CGROUP_PATH="${PREFIX}$(grep '0::' "/proc/${PID}/cgroup" | cut -d : -f 3-)"
+if [ -e "${CGROUP_PATH}" ]; then
+  echo "${CGROUP_PATH}"
+else
+  echo "Error: Path does not exist" > /dev/stderr
+  exit 1
+fi

--- a/contrib/plot
+++ b/contrib/plot
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import numpy as np
+import pandas as pd
+import matplotlib
+import matplotlib.pyplot as plt
+from pathlib import Path
+import itertools
+
+data = {'Mode': [], 'Tracer': [], 'MiB/s': []}
+
+modes = sorted(['async', 'mmap', 'sync'])
+tracers = sorted(['none', 'traceloop-active', 'traceloop-passive', 'strace'])
+
+runs = list(map(Path.as_posix, Path('.').glob('results-*')))
+N=len(runs)
+for (mode, tracer, run) in itertools.product(modes, tracers, runs):
+  with open(run + '/' + tracer + '-' + mode) as f:
+    line = [line for line in f.read().splitlines() if "read, MiB/s" in line][0]
+    mibps = float(line.split(' ')[-1])
+    data['Mode'].append(mode)
+    data['Tracer'].append(tracer)
+    data['MiB/s'].append(mibps)
+
+df = pd.DataFrame(data)
+
+minmax = []
+# this works because we sorted modes and tracers
+for mode in modes:
+  # use walrus to filter twice
+  distances_to_mins = [(dx := df[df['Tracer']==tracer])[dx['Mode']==mode]['MiB/s'].mean()-(dy := df[df['Tracer']==tracer])[dy['Mode']==mode]['MiB/s'].min() for tracer in tracers]
+  distances_to_maxs = [(dx := df[df['Tracer']==tracer])[dx['Mode']==mode]['MiB/s'].max()-(dy := df[df['Tracer']==tracer])[dy['Mode']==mode]['MiB/s'].mean() for tracer in tracers]
+  minmax.append([distances_to_mins, distances_to_maxs])
+
+fontsize=18
+plt.rc('legend', fontsize=fontsize)
+plt.rc('font', size=fontsize)
+plt.rc('axes', labelsize=fontsize)
+
+df = df.pivot_table(index='Tracer', columns='Mode', values='MiB/s')
+p=df.plot(kind='barh', xerr=minmax, title='sysbench fileio --file-test-mode=seqrd --file-io-mode=(sync|mmap|async), N=' + str(N), figsize=(15, 7), fontsize=fontsize)
+plt.xlabel('MiB/s (mean and min/max bar)')
+handles, labels = p.get_legend_handles_labels()
+p.legend(reversed(handles), reversed(labels), loc='upper left', bbox_to_anchor=(1,1), borderaxespad=0.)
+plt.tight_layout()
+plt.savefig('graph.png') # use PNG because Google Docs can't import SVG

--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$USER" != "root" ]; then
+  echo "Must run with sudo"
+  exit 1
+fi
+
+killall traceloop || true
+
+RESULTS="results-$(date +%s)"
+mkdir "$RESULTS"
+# sysbench fileio --file-io-mode=MODE:
+# MODE=sync makes a "read" syscall where strace/traceloop copy the buffer,
+# MODE=async makes an "io_submit" syscall where strace/traceloop do not copy the buffer,
+# MODE=mmap makes no syscall
+MODES="sync async mmap"
+
+for MODE in $MODES; do
+  NAME="strace-$MODE"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" strace -f -o "$RESULTS/$MODE.strace" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+done
+
+for MODE in $MODES; do
+  NAME="none-$MODE"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+done
+
+rm -f /run/traceloop.socket
+../traceloop serve &
+while ! sudo curl --unix-socket /run/traceloop.socket 'http://localhost/list'; do
+  sleep 1; echo "Waiting for traceloop to start up"
+done
+
+for MODE in $MODES; do
+  NAME="traceloop-active-$MODE"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  curl --unix-socket /run/traceloop.socket "http://localhost/dump-by-name?name=testload-${MODE}" > "$RESULTS/$MODE.traceloop"
+done
+
+for MODE in $MODES; do
+  NAME="traceloop-passive-$MODE"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+done
+
+killall traceloop
+rm -f /run/traceloop.socket

--- a/contrib/testload
+++ b/contrib/testload
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+MODE="$1"
+
+cd /tmp
+stat --file-system --format %T /tmp | grep -q tmpfs
+
+sysbench fileio prepare
+taskset -a -c 0 sysbench --threads=1 fileio --file-test-mode=seqrd --file-io-mode="$MODE" run
+
+# not needed because PrivateTmp: sysbench fileio cleanup


### PR DESCRIPTION
- Add helper script to find the cgroup v2 path for a process
Finding the right cgroup v2 path is some manual work even when the
cgroup name is known because the prefix depends on being either in
hybrid mode or v2-only mode.
Add a helper script that can be used as follows:
`sudo systemd-run --wait --collect --pipe -p 'ExecStartPre=/bin/sh -c "curl --unix-socket /run/traceloop.socket \"http://localhost/add?name=MYNAME&cgrouppath=$(/FOLDER/traceloop/contrib/current-cgroup)\""' /bin/ping -c 1 -W 1 -w 1 1.1.1.1`

- Add benchmark script