### PR TITLE
Support pread64 syscall and improve benchmark

### DIFF
--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -36,6 +36,7 @@ for MODE in $MODES; do
   NAME="traceloop-active-$MODE"
   systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" | tee > "$RESULTS/$NAME"
   curl --unix-socket /run/traceloop.socket "http://localhost/dump-by-name?name=testload-${MODE}" > "$RESULTS/$MODE.traceloop"
+  grep -q "prog with name \"testload-${MODE}\" not found" "$RESULTS/$MODE.traceloop" && { echo "Error: traceloop did register cgroup"; mv "$RESULTS" "failed-$RESULTS"; exit 1 ; }
 done
 
 for MODE in $MODES; do

--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -28,7 +28,7 @@ done
 
 rm -f /run/traceloop.socket
 ../traceloop serve &
-while ! sudo curl --unix-socket /run/traceloop.socket 'http://localhost/list'; do
+while ! curl --unix-socket /run/traceloop.socket 'http://localhost/list'; do
   sleep 1; echo "Waiting for traceloop to start up"
 done
 

--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -28,14 +28,14 @@ done
 
 rm -f /run/traceloop.socket
 ../traceloop serve &
-while ! curl --unix-socket /run/traceloop.socket 'http://localhost/list'; do
+while ! curl -f --unix-socket /run/traceloop.socket 'http://localhost/list'; do
   sleep 1; echo "Waiting for traceloop to start up"
 done
 
 for MODE in $MODES; do
   NAME="traceloop-active-$MODE"
-  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" | tee > "$RESULTS/$NAME"
-  curl --unix-socket /run/traceloop.socket "http://localhost/dump-by-name?name=testload-${MODE}" > "$RESULTS/$MODE.traceloop"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl -f --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  curl -f --unix-socket /run/traceloop.socket "http://localhost/dump-by-name?name=testload-${MODE}" > "$RESULTS/$MODE.traceloop"
   grep -q "prog with name \"testload-${MODE}\" not found" "$RESULTS/$MODE.traceloop" && { echo "Error: traceloop did register cgroup"; mv "$RESULTS" "failed-$RESULTS"; exit 1 ; }
 done
 

--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -18,12 +18,12 @@ MODES="sync async mmap"
 
 for MODE in $MODES; do
   NAME="strace-$MODE"
-  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" strace -f -o "$RESULTS/$MODE.strace" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" strace -f -o "$RESULTS/$MODE.strace" ./testload "$MODE" > "$RESULTS/$NAME"
 done
 
 for MODE in $MODES; do
   NAME="none-$MODE"
-  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" > "$RESULTS/$NAME"
 done
 
 rm -f /run/traceloop.socket
@@ -34,14 +34,14 @@ done
 
 for MODE in $MODES; do
   NAME="traceloop-active-$MODE"
-  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl -f --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" -p 'ExecStartPre=/bin/sh -c "curl -f --unix-socket /run/traceloop.socket \"http://localhost/add?name='"testload-${MODE}"'&cgrouppath=$(./current-cgroup)\""' ./testload "$MODE" > "$RESULTS/$NAME"
   curl -f --unix-socket /run/traceloop.socket "http://localhost/dump-by-name?name=testload-${MODE}" > "$RESULTS/$MODE.traceloop"
   grep -q "prog with name \"testload-${MODE}\" not found" "$RESULTS/$MODE.traceloop" && { echo "Error: traceloop did register cgroup"; mv "$RESULTS" "failed-$RESULTS"; exit 1 ; }
 done
 
 for MODE in $MODES; do
   NAME="traceloop-passive-$MODE"
-  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" | tee > "$RESULTS/$NAME"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" ./testload "$MODE" > "$RESULTS/$NAME"
 done
 
 killall traceloop

--- a/pkg/straceback/syscalls.go
+++ b/pkg/straceback/syscalls.go
@@ -288,5 +288,8 @@ func syscallGetDef(nr int) (args [6]uint64) {
 	if syscallNames[nr] == "getcwd" {
 		return [6]uint64{useNullByteLength | paramProbeAtExitMask, 0, 0, 0, 0, 0}
 	}
+	if syscallNames[nr] == "pread64" {
+		return [6]uint64{0, useRetAsParamLength | paramProbeAtExitMask, 0, 0, 0, 0}
+	}
 	return
 }


### PR DESCRIPTION
-  Dereference pread64 buffers    
    The pread64 syscall is used in the benchmark script in the "contrib/"
    folder.
    Later we should try to generate the argument annotation with a script having
    a heuristic for the data in
    /sys/kernel/debug/tracing/events/syscalls/sys_enter_NAME/format
    where "const" and "char *" are useful hints and then it will need to
    fix some corner cases like dereferencing a read buffer at exit.
- contrib: Fail benchmark when traceloop did not register the cgroup
- contrib: Remove unnecessary sudo since script runs as root
- contrib: Prepare benchmark to handle HTTP errors if traceloop supported them
- contrib: Remove unused tee in benchmark script