### PR TITLE
contrib: Add perf trace to the benchmark

### DIFF
--- a/contrib/current-cgroup
+++ b/contrib/current-cgroup
@@ -3,23 +3,29 @@ set -euo pipefail
 
 if [ "$#" -gt 0 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] ; }; then
   echo "Helper script to find the current cgroup v2 path"
-  echo "Usage: [PID=PROCESS_ID] $0"
+  echo "Usage: [PID=PROCESS_ID] [WITHPREFIX=0] $0"
   echo "  If PID is specified as environment variable, the cgroup path of"
   echo "  the given PID will be queried. Otherwise the PID of the script"
   echo "  process itself will be used."
+  echo "  If WITHPREFIX is not 1, only the cgroup name is printed."
   exit 1
 fi
 
 PID="${PID:-$$}"
+WITHPREFIX="${WITHPREFIX-1}"
 
-PREFIX="$(mount -l -t cgroup2 | awk '{print $3}')"
-if [ "$PREFIX" = "" ]; then
-  echo "Error: Traceloop doesn't support cgroup v1" > /dev/stderr
-  exit 1
+if [ "${WITHPREFIX}" != 1 ]; then
+  PREFIX=""
+else
+  PREFIX="$(mount -l -t cgroup2 | awk '{print $3}')"
+  if [ "$PREFIX" = "" ]; then
+    echo "Error: Traceloop doesn't support cgroup v1" > /dev/stderr
+    exit 1
+  fi
 fi
 
 CGROUP_PATH="${PREFIX}$(grep '0::' "/proc/${PID}/cgroup" | cut -d : -f 3-)"
-if [ -e "${CGROUP_PATH}" ]; then
+if [ "${WITHPREFIX}" != 1 ] || [ -e "${CGROUP_PATH}" ]; then
   echo "${CGROUP_PATH}"
 else
   echo "Error: Path does not exist" > /dev/stderr

--- a/contrib/plot
+++ b/contrib/plot
@@ -9,7 +9,7 @@ import itertools
 data = {'Mode': [], 'Tracer': [], 'MiB/s': []}
 
 modes = sorted(['async', 'mmap', 'sync'])
-tracers = sorted(['none', 'traceloop-active', 'traceloop-passive', 'strace'])
+tracers = sorted(['none', 'traceloop-active', 'traceloop-passive', 'strace', 'perf-trace'])
 
 runs = list(map(Path.as_posix, Path('.').glob('results-*')))
 N=len(runs)
@@ -17,6 +17,8 @@ for (mode, tracer, run) in itertools.product(modes, tracers, runs):
   with open(run + '/' + tracer + '-' + mode) as f:
     line = [line for line in f.read().splitlines() if "read, MiB/s" in line][0]
     mibps = float(line.split(' ')[-1])
+    if mode == 'sync' and tracer == 'perf-trace':
+      mibps = 0  # perf trace does not log the buffer content
     data['Mode'].append(mode)
     data['Tracer'].append(tracer)
     data['MiB/s'].append(mibps)

--- a/contrib/run-benchmark
+++ b/contrib/run-benchmark
@@ -17,6 +17,11 @@ mkdir "$RESULTS"
 MODES="sync async mmap"
 
 for MODE in $MODES; do
+  NAME="perf-trace-$MODE"
+  systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" sh -c "perf trace -o \"$RESULTS/$MODE.perf-trace\" -a -G \"\$(WITHPREFIX=0 ./current-cgroup)\" & while [ ! -e \"$RESULTS/$MODE.perf-trace\" ] || [ \"\$(cat \"$RESULTS/$MODE.perf-trace\" | wc -l)\" = 0 ]; do sleep 1; done; ./testload \"$MODE\" && killall perf" > "$RESULTS/$NAME"
+done
+
+for MODE in $MODES; do
   NAME="strace-$MODE"
   systemd-run --wait --collect --pipe -p PrivateTmp=yes --working-directory="$PWD" strace -f -o "$RESULTS/$MODE.strace" ./testload "$MODE" > "$RESULTS/$NAME"
 done


### PR DESCRIPTION
Compared to strace, "perf trace" is faster. Add it to the benchmark but
without the "sync" test because in contrast to strace and traceloop it
doesn't log the buffer contents of the pread64 syscall, making the
comparison unfair.

![graph](https://user-images.githubusercontent.com/1189130/91078664-40a56580-e643-11ea-870d-164e02370289.png)
