### PR TITLE
Dockerfile: install vanilla Go 1.16 instead of rpm

### DIFF
--- a/traceloop-builder.Dockerfile
+++ b/traceloop-builder.Dockerfile
@@ -1,16 +1,21 @@
 FROM fedora:26
 
 ENV GOPATH /go
+ENV PATH "/usr/local/go/bin:$PATH"
 
 # vim-common is needed for xxd
 # vim-minimal needs to be updated first to avoid an RPM conflict on man1/vim.1.gz
 RUN dnf update -y vim-minimal && \
-	dnf install -y llvm clang kernel-devel make binutils vim-common golang go-bindata ShellCheck git file
+	dnf install -y llvm clang kernel-devel make binutils vim-common go-bindata ShellCheck git file
 
 RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
 	echo "b1925c2c405458811f0c227266402cf1868b4de529f114722c2e3a5af4ac7bb2  shfmt" | sha256sum -c && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
+RUN curl -fsSLo go.tar.gz https://golang.org/dl/go1.16.4.linux-amd64.tar.gz && \
+	echo "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59  go.tar.gz" | sha256sum -c && \
+	mkdir -p /usr/local && \
+	tar -C /usr/local -xzf go.tar.gz
 RUN go get -u github.com/fatih/hclfmt
 
 RUN mkdir -p /src /go


### PR DESCRIPTION
Fedora 26 has Go 1.8 by default, but most Go packages require recent Go version like 1.16.
Without that, installation of `github.com/fatih/hclfmt` fails like that:

```
Step 5/6 : RUN go get -u github.com/fatih/hclfmt
package github.com/hashicorp/hcl/hcl/printer: cannot find package
"github.com/hashicorp/hcl/hcl/printer" in any of:
        /usr/lib/golang/src/github.com/hashicorp/hcl/hcl/printer (from
$GOROOT)
        /go/src/github.com/hashicorp/hcl/hcl/printer (from $GOPATH)
```

To upgrade Go to 1.16, we need to manually download a tarball from golang.org, unpack it to `/usr/local/go` to make it available.

Simply installing golang 1.16 of Fedora 34 does not work, because of missing dependencies in the existing Fedora 26 docker image.

Upgrading Fedora 26 to 34 also does not work, because at the moment traceloop requires kernel <= 4.16.

Fixes https://github.com/kinvolk/traceloop/issues/59