### PR TITLE
GHA: Remove daily cron job

### DIFF
--- a/.github/workflows/traceloop.yml
+++ b/.github/workflows/traceloop.yml
@@ -1,8 +1,6 @@
 name: Compile traceloop
 on:
   push:
-  schedule:
-    - cron: '0 2 * * *' # Night builds at 02:00
 
 jobs:
 


### PR DESCRIPTION
We're building and pushing images each day. It's not needed right now,
so let's disable it.

