### PR TITLE
Cross build docker image for arm64

### DIFF
--- a/.github/workflows/traceloop.yml
+++ b/.github/workflows/traceloop.yml
@@ -21,12 +21,45 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build traceloop
+      # We need to download arm64 cross compiler before building binary.
       run: |
+        sudo apt-get update
+        sudo apt-get install -qy gcc-aarch64-linux-gnu
         make all
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      if: github.ref == 'refs/heads/main'
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      if: github.ref == 'refs/heads/main'
+
+    - name: Login to Container Registry
+      uses: docker/login-action@v1
+      if: github.ref == 'refs/heads/main'
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Cross build gadget container for amd64 and arm64.
+      uses: docker/build-push-action@v2
+      # We cross build only when pushing to main because it takes a lot of time.
+      if: github.ref == 'refs/heads/main'
+      with:
+        context: .
+        file: traceloop.Dockerfile
+        push: true
+        tags: kinvolk/traceloop:${{ github.sha }}
+        # For the moment, we only support these two platforms.
+        platforms: linux/amd64,linux/arm64
 
     - name: Build container and publish to Registry
       id: publish-registry
       uses: elgohr/Publish-Docker-Github-Action@2.8
+      if: github.ref != 'refs/heads/main'
       with:
         name: docker.io/kinvolk/traceloop
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/traceloop.Dockerfile
+++ b/traceloop.Dockerfile
@@ -2,5 +2,8 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y \
   curl
 
-ADD traceloop /bin/
+# Add all traceloop binaries
+ADD traceloop-* /bin/
+# Then delete the one we do not need.
+RUN mv /bin/traceloop-linux-$(dpkg --print-architecture) /bin/traceloop && rm /bin/traceloop-*
 CMD ["/bin/traceloop", "k8s"]


### PR DESCRIPTION
Hi.

This PR add cross-building the traceloop image for arm64 architecture.
To do so, I needed to add cross-compilation for arm64 of traceloop binary to the `Makefile` and to modify the `Dockerfile` to `ADD` the corresponding binary depending of the destination architecture.

The build will only be triggered when pushing to gadget branch.
It was already tested and arm64 image were successfully generated:
https://hub.docker.com/layers/kinvolk/traceloop/2059b729c0ac8aa79016dacb06fbdaa1867c1446/images/sha256-6ea3cece8925a72350df7b42524067fc3418d5d80d4f454dbcbe60b4a58c9f92?context=explore

Best regards.